### PR TITLE
making sure libgpg-error is found by gpgme

### DIFF
--- a/external/Makefile
+++ b/external/Makefile
@@ -88,7 +88,9 @@ libgpg-error/Makefile: libgpg-error/config.sub libgpg-error/config.guess libgpg-
 			LDFLAGS="$(LDFLAGS)" \
 			--disable-languages \
 			--enable-static \
-			--host=$(HOST)
+			--host=$(HOST) \
+			--prefix=$(prefix)
+
 
 libgpg-error-build-stamp: libgpg-error/Makefile
 	$(MAKE) -C libgpg-error


### PR DESCRIPTION
as discussed on gnupg-devel, gpg-error-config relies on the --prefix set at configure time, which is then used by gpgme
